### PR TITLE
chore: change translation push workflow to trigger on workflow dispatch

### DIFF
--- a/.github/workflows/translation_push.yml
+++ b/.github/workflows/translation_push.yml
@@ -1,9 +1,9 @@
 name: Crowdin Push
 
 on:
-  push:
-    paths: ['i18n/**']
-    branches: [master]
+  workflow_dispatch:
+
+permissions: write-all
 
 jobs:
   crowdin-upload:


### PR DESCRIPTION
### Changes:

- Change the translation trigger workflow from push on master to workflow_dispatch as we need to trigger workflow on changes on the markdown files as well.