### PR TITLE
[DAPI] fix: height issue in documents page

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -5,7 +5,11 @@ import HomepageFeatures from '@site/src/features/Home';
 
 export default function Home(): JSX.Element {
   return (
-    <Layout title={'Home'} description='Deriv API documentation'>
+    <Layout
+      title={'Home'}
+      description='Deriv API documentation'
+      wrapperClassName='home_page_wrapper'
+    >
       <Head>
         <title>Deriv API | Customise your trading app</title>
         <meta

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -219,6 +219,13 @@ div[class*='sidebarViewport'] {
   align-items: center;
 }
 
+.main-wrapper {
+  height: calc(100vh - 4.5rem);
+  &.home_page_wrapper {
+    height: 100%;
+  }
+}
+
 .navbar {
   padding: 0 5vw;
   height: var(--nav-height);

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -220,7 +220,7 @@ div[class*='sidebarViewport'] {
 }
 
 .main-wrapper {
-  height: calc(100vh - 4.5rem);
+  min-height: calc(100vh - 4.5rem);
   &.home_page_wrapper {
     height: 100%;
   }


### PR DESCRIPTION
Changes### 

- Adding a custom class name for the homepage only to fix the header hiding issue
- Added back the calculated height to fix the height issue in documentation page