### PR TITLE
Sandeep/dapi 764/bug fixing

### DIFF
--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -967,8 +967,8 @@
   "Create token": {
     "message": "Create token"
   },
-  "Do not share tokens with the admin scope with unauthorized parties.": {
-    "message": "Do not share tokens with the admin scope with unauthorized parties."
+  "Do not share tokens with the admin scope with unauthorised parties.": {
+    "message": "Do not share tokens with the admin scope with unauthorised parties."
   },
   "Enable admin access": {
     "message": "Enable admin access"

--- a/i18n/fr/code.json
+++ b/i18n/fr/code.json
@@ -967,7 +967,7 @@
   "Create token": {
     "message": "Créer un Token"
   },
-  "Do not share tokens with the admin scope with unauthorized parties.": {
+  "Do not share tokens with the admin scope with unauthorised parties.": {
     "message": "Ne partagez pas les Tokens à l'aide de l'accès Admin avec des personnes non autorisées."
   },
   "Enable admin access": {

--- a/src/components/custom-tabs/custom-tabs.scss
+++ b/src/components/custom-tabs/custom-tabs.scss
@@ -6,7 +6,7 @@
   font-size: 20px;
   font-family: var(--ibm-font-family-base);
   font-weight: var(--ifm-font-weight-semibold);
-  overflow-x: hidden;
+  overflow-x: visible;
 
   &_header {
     margin-block: 45px;

--- a/src/features/dashboard/components/api-token-card/api-token-cards.tsx
+++ b/src/features/dashboard/components/api-token-card/api-token-cards.tsx
@@ -49,7 +49,7 @@ const ApiTokenCard = ({ register, name, label, description, ...rest }: IApiToken
       <>
         <SectionMessage
           message={translate({
-            message: 'Do not share tokens with the admin scope with unauthorized parties.',
+            message: 'Do not share tokens with the admin scope with unauthorised parties.',
           })}
           size='md'
           status='warning'

--- a/src/features/dashboard/components/api-token-form/create-token-field.tsx
+++ b/src/features/dashboard/components/api-token-form/create-token-field.tsx
@@ -83,14 +83,12 @@ const CreateTokenField = ({
 
   return (
     <React.Fragment>
-      <div
-        onChange={handleInputChange}
-        className={`${styles.customTextInput} ${error_border_active ? 'error-border' : ''}`}
-      >
-        <div className={styles.textfield}>
+      <div onChange={handleInputChange} className={styles.customTextInput}>
+        <div>
           <TextField
             label={translate({ message: 'Enter your token name' })}
             placeholder={translate({ message: 'Token name' })}
+            status={error_border_active ? 'error' : null}
             {...register}
           />
         </div>

--- a/src/features/dashboard/components/api-token-table/api-token-table.tsx
+++ b/src/features/dashboard/components/api-token-table/api-token-table.tsx
@@ -31,7 +31,7 @@ const tableColumns: TTokenColumn[] = [
   {
     Header: translate({ message: 'Account Type' }),
     Cell: AccountTypeCell,
-    width: '20%',
+    width: '15%',
   },
   {
     Header: translate({ message: 'Token' }),
@@ -43,7 +43,7 @@ const tableColumns: TTokenColumn[] = [
     Header: translate({ message: 'Token scopes' }),
     accessor: 'scopes',
     Cell: ScopesCell,
-    width: '25%',
+    width: '20%',
     maxWidth: 300,
   },
   {

--- a/src/features/dashboard/components/app-register/app-register.tsx
+++ b/src/features/dashboard/components/app-register/app-register.tsx
@@ -75,7 +75,7 @@ const AppRegister: React.FC<TAppRegisterProps> = ({ submit }) => {
             <input
               {...register('name')}
               placeholder={translate({ message: `Enter your app's name` })}
-              className='app_register_container_input'
+              className='app-register-container__input'
             />
           </div>
           <div className='app-register-container__fields__button'>

--- a/src/features/dashboard/components/apps-table/apps-table.tsx
+++ b/src/features/dashboard/components/apps-table/apps-table.tsx
@@ -252,7 +252,7 @@ const AppsTable = ({ apps }: AppsTableProps) => {
           />
         ),
         accessor: 'name',
-        width: '20%',
+        width: '25%',
       },
       {
         Header: (
@@ -265,7 +265,7 @@ const AppsTable = ({ apps }: AppsTableProps) => {
         ),
         accessor: 'app_id',
         Cell: CopyTextCell,
-        width: '10%',
+        width: '14%',
       },
       {
         Header: translate({ message: 'OAuth scopes' }),

--- a/src/theme/NavbarItem/LocaleDropdownNavbarItem/locale-dropdown-navbar-item.scss
+++ b/src/theme/NavbarItem/LocaleDropdownNavbarItem/locale-dropdown-navbar-item.scss
@@ -32,6 +32,7 @@
     gap: 10px;
     flex-direction: row;
     align-items: center;
+    padding-top: 4px;
   }
 
   .navbar__link {


### PR DESCRIPTION
## Change

The  App's Name and App id column padding and arrows not per design (see the api token table for reference)
The titles are not in one line 
The whole table size is not as per design (should be same as api token table)
Change name "Application Manager" to "App Manager"
The "Enter your app name" has an outline
The EN (Language switcher) is not in one line on the Header