### PR TITLE
fix: :fire: account switcher overlapping issue fixed

### DIFF
--- a/src/features/dashboard/components/api-token-table/api-table.module.scss
+++ b/src/features/dashboard/components/api-token-table/api-table.module.scss
@@ -52,7 +52,7 @@
       position: sticky;
       top: 0;
       position: sticky;
-      z-index: 999;
+      z-index: 1;
     }
     tr {
       background-color: transparent;


### PR DESCRIPTION
## Change

- Updated overlapping account issue in the app token table

### Before
<img width="842" alt="Screenshot 2024-10-08 at 2 12 30 PM" src="https://github.com/user-attachments/assets/d8ed238c-414d-4c22-8c5c-f1c6455a9a69">

### After
![Screenshot 2024-10-08 at 2 15 32 PM](https://github.com/user-attachments/assets/d89bac16-7a8d-4f7e-865a-87fa76d86bce)
