### PR TITLE
Moiz-ENGT-2350-Apostrophe inconsistencies in Scope of authorisation section & Markup URL update

### DIFF
--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -493,10 +493,10 @@
     "message": "Trading information"
   },
   "You‘ll be able to view your clients’ trading information, including their account balance.": {
-    "message": "You‘ll be able to view your clients’ trading information, including their account balance."
+    "message": "You'll be able to view your clients' trading information, including their account balance."
   },
   "You‘ll be able to perform deposits and withdrawals on your clients’ behalf.": {
-    "message": "You‘ll be able to perform deposits and withdrawals on your clients’ behalf."
+    "message": "You'll be able to perform deposits and withdrawals on your clients' behalf."
   },
   "Full account access, including the access to manage security tokens.": {
     "message": "Full account access, including the access to manage security tokens."
@@ -721,7 +721,7 @@
     "message": "You'll be able to perform deposits and withdrawals on your clients' behalf."
   },
   "Grant admin access only when it’s essential for your app's workflow.": {
-    "message": "Grant admin access only when it’s essential for your app's workflow."
+    "message": "Grant admin access only when it's essential for your app's workflow."
   },
   "Update application": {
     "message": "Update application"

--- a/src/features/dashboard/update-app/AppUpdateForm/index.tsx
+++ b/src/features/dashboard/update-app/AppUpdateForm/index.tsx
@@ -113,7 +113,8 @@ const AppUpdateForm = ({ initialValues, submit, onCancel, is_loading }: TAppForm
             </Translate>{' '}
             <UnderlinedLink
               text={translate({ message: 'documentation' })}
-              linkTo="https://developers.deriv.com" />
+              linkTo='https://developers.deriv.com/docs/mark-up'
+            />
             .
           </Text>
           <SectionMessage


### PR DESCRIPTION
fix: updated apostrophe to be same in scope of auth section and change link of markup documentation from https://developers.deriv.com/ to https://developers.deriv.com/docs/mark-up 

![Screenshot 2025-05-06 at 3 38 26 PM](https://github.com/user-attachments/assets/a6d88bea-9dbf-478e-8d12-15795b02f2ae)
![Screenshot 2025-05-06 at 3 38 46 PM](https://github.com/user-attachments/assets/38ff9a1b-33f2-45fd-b750-d5937edef7f7)
