### PR TITLE
Moiz-WEBREL-4297-[API Dashboard] Markup documentation hyperlink is not opening in a new tab

### DIFF
--- a/src/features/dashboard/update-app/AppUpdateForm/index.tsx
+++ b/src/features/dashboard/update-app/AppUpdateForm/index.tsx
@@ -25,7 +25,7 @@ const Explanations: React.FC<{ children: React.ReactNode }> = ({ children }) => 
 
 const UnderlinedLink: React.FC<{ text: string; linkTo: string }> = ({ text, linkTo }) => {
   return (
-    <a className='underlined_link' href={linkTo}>
+    <a className='underlined_link' href={linkTo} target='_blank' rel='noreferrer'>
       {text}
     </a>
   );


### PR DESCRIPTION
fix: update link to open in new tab