### PR TITLE
Potential fix for code scanning alert no. 54: Use of a known vulnerable action

### DIFF
--- a/.github/workflows/release_production.yml
+++ b/.github/workflows/release_production.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - name: Download Build Artifact
-        uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935
+        uses: actions/download-artifact@v4.1.3
         with:
           name: build
           path: build

--- a/.github/workflows/release_production.yml
+++ b/.github/workflows/release_production.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - name: Download Build Artifact
-        uses: actions/download-artifact@v4.1.3
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           name: build
           path: build


### PR DESCRIPTION
Potential fix for [https://github.com/deriv-com/deriv-api-docs/security/code-scanning/54](https://github.com/deriv-com/deriv-api-docs/security/code-scanning/54)

To fix the issue, the workflow should update the `actions/download-artifact` action to version `4.1.3`, which is the latest secure version as recommended. This involves replacing the specific commit hash (`6b208ae046db98c579e8a3aa621ab581ff575935`) with the version tag `v4.1.3`. This change ensures that the workflow uses a secure and patched version of the action while maintaining its functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
