### PR TITLE
Potential fix for code scanning alert no. 84: Log injection

### DIFF
--- a/examples/buy_contract/index.js
+++ b/examples/buy_contract/index.js
@@ -55,7 +55,8 @@ const buyContractResponse = async (res) => {
       const entry_tick = data.proposal_open_contract.entry_tick;
       const current_spot = data.proposal_open_contract.current_spot;
       if (typeof entry_tick !== 'undefined') entry_spot = entry_tick;
-      console.log(`Entry spot ${String(entry_spot)} \n`);
+      const sanitizedEntrySpot = String(entry_spot).replace(/\n|\r/g, "");
+      console.log(`Entry spot ${sanitizedEntrySpot} \n`);
       console.log(`Current spot ${String(current_spot)} \n`);
       console.log(`Difference ${String(current_spot - entry_spot)} \n`);
     }


### PR DESCRIPTION
Potential fix for [https://github.com/deriv-com/deriv-api-docs/security/code-scanning/84](https://github.com/deriv-com/deriv-api-docs/security/code-scanning/84)

To fix the issue, the untrusted `entry_tick` value should be sanitized before being logged. Specifically, newline characters (`\n` and `\r`) should be removed from the value to prevent log injection. This can be achieved using `String.prototype.replace` to ensure that the logged value is safe.

The fix involves modifying the code on line 58 to sanitize `entry_spot` before logging it. This ensures that any malicious input from the WebSocket message cannot manipulate the log output.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
