### PR TITLE
fix: workflow permissons

### DIFF
--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -10,6 +10,8 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11

--- a/.github/workflows/release_production.yml
+++ b/.github/workflows/release_production.yml
@@ -10,6 +10,8 @@ jobs:
     name: Builds and Publishes to Cloudflare Pages Production
     environment: Production
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       RELEASE_VERSION: ${{ steps.extract_version.outputs.RELEASE_VERSION }}
     steps:
@@ -50,6 +52,8 @@ jobs:
     name: Send Slack Notification
     environment: Production
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: always()
     needs: [build_and_publish]
     steps:
@@ -75,6 +79,8 @@ jobs:
     name: Publish to Vercel DR
     runs-on: ubuntu-latest
     environment: Production
+    permissions:
+      contents: read
     needs: [build_and_publish]
     steps:
       - name: Checkout

--- a/.github/workflows/release_staging.yml
+++ b/.github/workflows/release_staging.yml
@@ -8,6 +8,8 @@ jobs:
     name: Builds and Publishes to Cloudflare Pages Staging
     runs-on: ubuntu-latest # TODO: Replace this with the appropriate runner for Deriv-Api-Docs when provided
     environment: Staging
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11

--- a/.github/workflows/release_test.yml
+++ b/.github/workflows/release_test.yml
@@ -12,6 +12,8 @@ jobs:
     name: Builds and Publishes to Cloudflare Pages Test
     environment: Staging
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       RELEASE_VERSION: ${{ steps.extract_version.outputs.RELEASE_VERSION }}
     steps:

--- a/.github/workflows/translation_push.yml
+++ b/.github/workflows/translation_push.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   crowdin-upload:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11


### PR DESCRIPTION
This pull request updates multiple GitHub Actions workflows to explicitly define `permissions` for the `contents: read` scope. This change is applied across several workflows to enhance security by limiting the permissions granted to the workflows.

### Workflow updates for permissions:

* [`.github/workflows/coveralls.yml`](diffhunk://#diff-02ea8b56d85127dc4dd5bdc9b82a89b4727d6ad5964dfb8d5b47177fd5030a77R13-R14): Added `permissions: contents: read` to the `build` job.
* [`.github/workflows/release_production.yml`](diffhunk://#diff-93c7ed8fd6afff1de03995a214df3faa4dcd98168fed9759c17e5db6e3147a09R13-R14): Added `permissions: contents: read` to multiple jobs, including `Builds and Publishes to Cloudflare Pages Production`, `Send Slack Notification`, and `Publish to Vercel DR`. [[1]](diffhunk://#diff-93c7ed8fd6afff1de03995a214df3faa4dcd98168fed9759c17e5db6e3147a09R13-R14) [[2]](diffhunk://#diff-93c7ed8fd6afff1de03995a214df3faa4dcd98168fed9759c17e5db6e3147a09R55-R56) [[3]](diffhunk://#diff-93c7ed8fd6afff1de03995a214df3faa4dcd98168fed9759c17e5db6e3147a09R82-R83)
* [`.github/workflows/release_staging.yml`](diffhunk://#diff-5085d81e5d6d1c49ba0817f67c006ccef42d9c40fbae2b7f569cd5b442347191R11-R12): Added `permissions: contents: read` to the `Builds and Publishes to Cloudflare Pages Staging` job.
* [`.github/workflows/release_test.yml`](diffhunk://#diff-4dbeb46fb23b5e0a6848000fed331c0a8d0b7c81c2ae45a0ad9fa889458c7097R15-R16): Added `permissions: contents: read` to the `Builds and Publishes to Cloudflare Pages Test` job.
* [`.github/workflows/translation_push.yml`](diffhunk://#diff-ceafd55fdc1391c45b7bbf5f920bec7b6c2d9ae2ca4bb102c014660570c47b44R9-R10): Added `permissions: contents: read` to the `crowdin-upload` job.