### PR TITLE
Maryia/feat: replace deriv tech link with deriv<ed> link

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -128,8 +128,8 @@ const config = {
             className: 'external-nav-link',
           },
           {
-            to: 'https://tech.deriv.com/',
-            label: 'Deriv tech',
+            to: 'https://derivai.substack.com/',
+            label: 'Deriv<ed>',
             position: 'left',
             className: 'external-nav-link',
           },

--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -14,8 +14,8 @@
   "API explorer": {
     "message": "API explorer"
   },
-  "Deriv Tech": {
-    "message": "Deriv Tech"
+  "Deriv<ed>": {
+    "message": "Deriv<ed>"
   },
   "Bug bounty": {
     "message": "Bug bounty"

--- a/i18n/en/docusaurus-theme-classic/navbar.json
+++ b/i18n/en/docusaurus-theme-classic/navbar.json
@@ -11,9 +11,9 @@
     "message": "API explorer",
     "description": "Navbar item with label API explorer"
   },
-  "item.label.Deriv tech": {
-    "message": "Deriv tech",
-    "description": "Navbar item with label Deriv tech"
+  "item.label.Deriv<ed>": {
+    "message": "Deriv<ed>",
+    "description": "Navbar item with label Deriv<ed>"
   },
   "item.label.Bug bounty": {
     "message": "Bug bounty",

--- a/i18n/fr/code.json
+++ b/i18n/fr/code.json
@@ -14,8 +14,8 @@
   "API explorer": {
     "message": "Explorateur d'API"
   },
-  "Deriv Tech": {
-    "message": "Deriv Tech"
+  "Deriv<ed>": {
+    "message": "Deriv<ed>"
   },
   "Bug bounty": {
     "message": "Prime aux bogues"

--- a/i18n/fr/docusaurus-theme-classic/navbar.json
+++ b/i18n/fr/docusaurus-theme-classic/navbar.json
@@ -11,9 +11,9 @@
     "message": "Explorateur d'API",
     "description": "Navbar item with label API explorer"
   },
-  "item.label.Deriv tech": {
-    "message": "Deriv tech",
-    "description": "Navbar item with label Deriv tech"
+  "item.label.Deriv<ed>": {
+    "message": "Deriv<ed>",
+    "description": "Navbar item with label Deriv<ed>"
   },
   "item.label.Bug bounty": {
     "message": "Prime aux bogues",

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -60,12 +60,12 @@ const Footer = () => {
           </li>
           <li>
             <a
-              href='https://deriv.com/derivtech'
+              href='https://derivai.substack.com/'
               target='_blank'
               className={styles.Link}
               rel='noreferrer'
             >
-              <Translate>Deriv Tech</Translate> <LabelPairedArrowUpRightSmRegularIcon />
+              <Translate>Deriv&lt;ed&gt;</Translate> <LabelPairedArrowUpRightSmRegularIcon />
             </a>
           </li>
           <li>
@@ -159,13 +159,13 @@ const Footer = () => {
                 </li>
                 <li>
                   <a
-                    href='https://deriv.com/derivtech'
+                    href='https://derivai.substack.com/'
                     target='_blank'
                     className={styles.Link}
                     rel='noreferrer'
                   >
                     <Text size='sm' className={styles.labelcolor}>
-                      <Translate>Deriv Tech</Translate>
+                      <Translate>Deriv&lt;ed&gt;</Translate>
                     </Text>
                     <LabelPairedArrowUpRightSmRegularIcon />
                   </a>


### PR DESCRIPTION
- Replace the Deriv Tech link in the footer with the [Deriv<ed> Substack link](https://derivai.substack.com/) to match deriv.com